### PR TITLE
Add native multimodal Discord attachment relay

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { mkdirSync, readFileSync } from 'node:fs';
 import { config } from './config.js';
 import { logger } from './logger.js';
+import { downloadAttachments, type AttachmentMeta } from './media.js';
 import {
   readSessionCreatedAt,
   resolveChannelSessionDir,
@@ -40,7 +41,7 @@ export interface ChannelSessionStatus {
 export async function invokeAgent(
   channelFolder: string,
   userText: string,
-  opts?: { model?: string; thinking?: string; signal?: AbortSignal },
+  opts?: { model?: string; thinking?: string; signal?: AbortSignal; attachments?: string | null },
 ): Promise<AgentResult> {
   const sessionDir = resolveChannelSessionDir(channelFolder);
   mkdirSync(sessionDir, { recursive: true });
@@ -60,6 +61,23 @@ export async function invokeAgent(
   // Extra flags
   if (config.piExtraFlags) {
     args.push(...config.piExtraFlags.split(/\s+/).filter(Boolean));
+  }
+
+  // Download attachments and pass as @file args (pi handles all types natively)
+  if (opts?.attachments) {
+    try {
+      const metas: AttachmentMeta[] = JSON.parse(opts.attachments);
+      const messageId = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+      const downloaded = await downloadAttachments(metas, channelFolder, messageId);
+      for (const file of downloaded) {
+        args.push(`@${file.filePath}`);
+      }
+      if (downloaded.length > 0) {
+        logger.info({ channelFolder, count: downloaded.length }, 'Attached files for pi');
+      }
+    } catch (err: any) {
+      logger.warn({ err: err.message }, 'Failed to process attachments');
+    }
   }
 
   // Prompt (must be last)

--- a/src/db.ts
+++ b/src/db.ts
@@ -50,6 +50,7 @@ export function initDb(): void {
 
   ensureTableColumn('channels', 'model_override', "text not null default ''");
   ensureTableColumn('channels', 'thinking_override', "text not null default ''");
+  ensureTableColumn('message_queue', 'attachments', 'text');
 
   logger.info({ path: config.dbPath }, 'Database initialized');
 }
@@ -139,11 +140,12 @@ export function enqueueMessage(msg: {
   senderName: string;
   content: string;
   timestamp: string;
+  attachments?: string | null;
 }): void {
   db.prepare(`
-    insert into message_queue (channel_jid, sender, sender_name, content, timestamp)
-    values (?, ?, ?, ?, ?)
-  `).run(msg.channelJid, msg.sender, msg.senderName, msg.content, msg.timestamp);
+    insert into message_queue (channel_jid, sender, sender_name, content, timestamp, attachments)
+    values (?, ?, ?, ?, ?, ?)
+  `).run(msg.channelJid, msg.sender, msg.senderName, msg.content, msg.timestamp, msg.attachments ?? null);
 }
 
 export function claimNextMessage(channelJid?: string): QueuedMessage | undefined {

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -23,6 +23,7 @@ import {
   registerChannel as dbRegisterChannel,
   enqueueMessage,
 } from './db.js';
+import type { AttachmentMeta } from './media.js';
 import type { RegisteredChannel } from './types.js';
 import { handleAutocomplete, handleChatCommand, registerGlobalCommands } from './slash-commands.js';
 
@@ -122,16 +123,16 @@ async function handleMessage(message: Message): Promise<void> {
     }
   }
 
-  // Attachments → placeholders
+  // Attachments → extract metadata for downstream download
+  let attachmentsJson: string | null = null;
   if (message.attachments.size > 0) {
-    const descs = [...message.attachments.values()].map((att) => {
-      const ct = att.contentType || '';
-      if (ct.startsWith('image/')) return `[Image: ${att.name || 'image'}]`;
-      if (ct.startsWith('video/')) return `[Video: ${att.name || 'video'}]`;
-      if (ct.startsWith('audio/')) return `[Audio: ${att.name || 'audio'}]`;
-      return `[File: ${att.name || 'file'}]`;
-    });
-    content = content ? `${content}\n${descs.join('\n')}` : descs.join('\n');
+    const metas: AttachmentMeta[] = [...message.attachments.values()].map((att) => ({
+      url: att.url,
+      name: att.name || 'file',
+      contentType: att.contentType || '',
+      size: att.size || 0,
+    }));
+    attachmentsJson = JSON.stringify(metas);
   }
 
   // Reply context
@@ -180,7 +181,7 @@ async function handleMessage(message: Message): Promise<void> {
   if (!content) return;
 
   // ── Enqueue ──
-  enqueueMessage({ channelJid: jid, sender, senderName, content, timestamp });
+  enqueueMessage({ channelJid: jid, sender, senderName, content, timestamp, attachments: attachmentsJson });
   logger.info({ jid, sender: senderName, len: content.length }, 'Message enqueued');
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { config } from './config.js';
 import { logger } from './logger.js';
 import { initDb, closeDb, registerChannel, unregisterChannel, getAllChannels } from './db.js';
 import { startDiscord, stopDiscord, getBotTag } from './discord.js';
+import { startMediaCleanup } from './media.js';
 import { startProcessingLoop, stopProcessingLoop } from './queue.js';
 import { validateSessionFolder } from './session-path.js';
 import type { RegisteredChannel } from './types.js';
@@ -46,6 +47,7 @@ async function startGateway(): Promise<void> {
 
   await startDiscord();
   startProcessingLoop();
+  startMediaCleanup();
 
   logger.info({
     bot: getBotTag(),

--- a/src/media.ts
+++ b/src/media.ts
@@ -1,0 +1,124 @@
+/**
+ * Media handling — download Discord attachments to disk for pi @file processing.
+ *
+ * The gateway acts as a pure relay: download to disk, pass path to pi via @file,
+ * let pi decide how to handle each file type natively.
+ * Periodic cleanup removes stale media files.
+ */
+
+import { mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { config } from './config.js';
+import { logger } from './logger.js';
+
+/** Metadata for a single Discord attachment (from discord.js) */
+export interface AttachmentMeta {
+  url: string;
+  name: string;
+  contentType: string;
+  size: number;
+}
+
+/** A successfully downloaded file */
+export interface DownloadedFile {
+  filePath: string;
+  originalName: string;
+  size: number;
+}
+
+/** Download timeout per file (30s) */
+const DOWNLOAD_TIMEOUT_MS = 30_000;
+
+/** Media TTL before cleanup (1 hour) */
+const MEDIA_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Download all attachments to a per-message directory under the channel session.
+ * Returns the list of successfully downloaded files.
+ */
+export async function downloadAttachments(
+  attachments: AttachmentMeta[],
+  channelFolder: string,
+  messageId: string,
+): Promise<DownloadedFile[]> {
+  if (attachments.length === 0) return [];
+
+  const mediaDir = join(config.sessionsDir, channelFolder, 'media', `msg-${messageId}`);
+  mkdirSync(mediaDir, { recursive: true });
+
+  const results: DownloadedFile[] = [];
+
+  for (const att of attachments) {
+    try {
+      const res = await fetch(att.url, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
+      if (!res.ok) {
+        logger.warn({ name: att.name, status: res.status }, 'Attachment download failed');
+        continue;
+      }
+
+      const buffer = Buffer.from(await res.arrayBuffer());
+      const safeName = sanitizeFilename(att.name || 'file');
+      // Prefix with index to avoid name collisions
+      const fileName = results.length > 0 ? `${results.length}_${safeName}` : safeName;
+      const filePath = join(mediaDir, fileName);
+      await writeFile(filePath, buffer);
+
+      results.push({ filePath, originalName: att.name || 'file', size: buffer.length });
+      logger.debug({ name: att.name, size: buffer.length, path: filePath }, 'Attachment downloaded');
+    } catch (err: any) {
+      logger.warn({ name: att.name, err: err.message }, 'Attachment download error');
+    }
+  }
+
+  return results;
+}
+
+/** Make filenames safe for the filesystem */
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 200);
+}
+
+/** Start the periodic media cleanup timer */
+export function startMediaCleanup(): void {
+  // Run every 30 minutes
+  setInterval(() => {
+    try {
+      cleanupExpiredMedia();
+    } catch (err: any) {
+      logger.warn({ err: err.message }, 'Media cleanup error');
+    }
+  }, 30 * 60 * 1000);
+}
+
+/** Remove media directories older than MEDIA_TTL_MS */
+function cleanupExpiredMedia(): void {
+  const now = Date.now();
+  let cleaned = 0;
+
+  try {
+    const channelDirs = readdirSync(config.sessionsDir, { withFileTypes: true });
+    for (const chDir of channelDirs) {
+      if (!chDir.isDirectory()) continue;
+      const mediaRoot = join(config.sessionsDir, chDir.name, 'media');
+      try {
+        const msgDirs = readdirSync(mediaRoot, { withFileTypes: true });
+        for (const msgDir of msgDirs) {
+          if (!msgDir.isDirectory()) continue;
+          const dirPath = join(mediaRoot, msgDir.name);
+          try {
+            const st = statSync(dirPath);
+            if (now - st.mtimeMs > MEDIA_TTL_MS) {
+              rmSync(dirPath, { recursive: true, force: true });
+              cleaned++;
+            }
+          } catch { /* skip */ }
+        }
+      } catch { /* no media dir — fine */ }
+    }
+  } catch { /* sessions dir doesn't exist yet */ }
+
+  if (cleaned > 0) {
+    logger.info({ cleaned }, 'Cleaned up expired media directories');
+  }
+}

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -73,7 +73,7 @@ function dispatch(): void {
     activeTasks++;
 
     // Fire and forget — processMessage handles its own errors
-    processMessage(jid, msg.rowid, msg.sender_name, msg.content)
+    processMessage(jid, msg.rowid, msg.sender_name, msg.content, msg.attachments)
       .finally(() => {
         activeChannels.delete(jid);
         activeTasks--;
@@ -86,6 +86,7 @@ async function processMessage(
   rowid: number,
   senderName: string,
   content: string,
+  attachments?: string | null,
 ): Promise<void> {
   const channel = getChannel(jid);
   if (!channel) {
@@ -127,6 +128,7 @@ async function processMessage(
     const result = await invokeAgent(channel.folder, prompt, {
       model: effective.rawModelRef || undefined,
       thinking: effective.hasManagedThinking ? effective.effectiveThinking : undefined,
+      attachments,
     });
 
     await stopTypingLoop();

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,8 @@ export interface QueuedMessage {
   content: string;
   timestamp: string;
   status: 'pending' | 'processing' | 'done' | 'failed';
+  /** JSON array of attachment metadata, or null */
+  attachments: string | null;
 }
 
 /** Agent invocation result */


### PR DESCRIPTION
## Summary
- relay Discord attachments via filesystem instead of placeholder text
- store attachment metadata in the queue and download files before invoking pi
- pass downloaded files to pi as `@file` args so pi can use native multimodal handling
- add periodic media cleanup for session attachment directories

## Validation
- npm run build