### PR TITLE
   Add optional auto-threading and fix ESM/git install issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1950,9 +1950,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1970,9 +1967,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1990,9 +1984,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2010,9 +2001,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2030,9 +2018,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "scripts": {
     "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
+    "prepare": "test ! -d src || npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint .",

--- a/src/agent/queue.ts
+++ b/src/agent/queue.ts
@@ -19,7 +19,7 @@ import {
   getChannel,
 } from '../db.js';
 import { invokeAgent } from './invoke.js';
-import { sendResponse, setTyping } from '../discord/client.js';
+import { sendResponse, setTyping, autoThreadOnMessage } from '../discord/client.js';
 import { computeEffectiveChannelSettings } from './channel-settings.js';
 
 /** Channels currently being processed (per-channel serial lock) */
@@ -227,11 +227,25 @@ async function processMessage(
     }
 
     if (result.ok) {
-      const sent = await sendResponse(jid, result.text);
-      if (!sent) {
+      const sentMessage = await sendResponse(jid, result.text);
+      if (!sentMessage) {
         markMessageFailed(rowid);
         logger.warn({ jid }, 'Agent response generated but could not be delivered to Discord');
         return;
+      }
+
+      // Scheduled tasks fire into a parent channel with no anchor user
+      // message, so the user has nowhere clean to reply. Mirror the
+      // inbound auto-thread behaviour here: start a thread on the bot's
+      // response and register it under the parent's workspace, so the
+      // user reply lands inside the thread and routes back to Pi
+      // automatically.
+      if (config.autoThread && senderName === 'Scheduler') {
+        const parent = getChannel(jid);
+        if (parent) {
+          const dateStr = new Date().toISOString().slice(0, 10);
+          await autoThreadOnMessage(sentMessage, parent, `check-in ${dateStr}`);
+        }
       }
 
       logMessage(jid, 'assistant', result.text);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { existsSync, realpathSync } from 'node:fs';
-import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { RegisteredChannel } from '../types.js';
@@ -23,7 +22,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
     }
     case 'start': {
       if (await maybeRunFirstTimeSetup()) return 0;
-      checkPiDependencies();
+      await checkPiDependencies();
       const { startGateway } = await import('../index.js');
       await startGateway();
       return 0;
@@ -431,19 +430,26 @@ async function reportError(command: string | undefined, err: unknown): Promise<v
   console.error(`Error: ${message}`);
 }
 
-function checkPiDependencies(): void {
-  const require = createRequire(import.meta.url);
-
+async function checkPiDependencies(): Promise<void> {
+  // Use dynamic import() rather than CJS require.resolve so this works
+  // when the peer (e.g. @earendil-works/pi-ai) is an ESM-only package
+  // whose package.json "exports" only declares the "import" condition.
+  // require.resolve cannot resolve such packages and produces a false
+  // negative even when they're installed.
   try {
-    require.resolve('@earendil-works/pi-ai');
+    await import('@earendil-works/pi-ai');
     return;
   } catch {
     // not found — check if the legacy package is installed instead
   }
 
   let hint = '';
+  // Use an indirect specifier so TypeScript doesn't statically resolve the
+  // legacy package (it may not be installed in this devDependencies set,
+  // and we only care whether it's present at runtime).
+  const legacyPkg = '@mariozechner/pi-ai';
   try {
-    require.resolve('@mariozechner/pi-ai');
+    await import(legacyPkg);
     hint =
       '\n\nDetected legacy @mariozechner/pi-ai. This package has moved to @earendil-works/pi-ai.' +
       '\nUpgrade pi to v0.74.0+ to get the new packages.';

--- a/src/config.ts
+++ b/src/config.ts
@@ -197,6 +197,22 @@ export const config = {
 
   /** Max combined attachment size per Discord message in bytes (0 disables the limit) */
   maxTotalAttachmentBytes: envInt('MAX_TOTAL_ATTACHMENT_BYTES', 50 * 1024 * 1024, { min: 0 }),
+
+  /**
+   * When true, the first @-mention in a registered parent text channel
+   * spawns a Discord thread on that message; subsequent replies are
+   * routed into the thread.  The thread inherits its parent's workspace
+   * (cwd), model, and thinking overrides; it gets its own session-dir so
+   * each thread is an isolated Pi conversation history.
+   */
+  autoThread: envBool('AUTO_THREAD', false),
+
+  /**
+   * Thread auto-archive duration in minutes.  Discord accepts 60, 1440,
+   * 4320, or 10080 — values outside that set may be downgraded by the
+   * server to the closest allowed option.
+   */
+  autoThreadArchiveMinutes: envInt('AUTO_THREAD_ARCHIVE_MIN', 1440, { min: 1 }),
 } as const;
 
 export type Config = typeof config;

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -15,6 +15,7 @@ import {
   type Message,
   type TextChannel,
   type DMChannel,
+  type ThreadAutoArchiveDuration,
 } from 'discord.js';
 import { type RegisteredChannel } from '../types.js';
 import { config } from '../config.js';
@@ -230,16 +231,64 @@ async function handleMessage(message: Message): Promise<void> {
   }
   if (!content) return;
 
+  // ── Auto-thread ──
+  // When AUTO_THREAD is enabled and the message arrived in a registered
+  // parent text channel (not already inside a thread, not a DM), create a
+  // Discord thread on the user message and register it under the same
+  // workspace/model/cwd as the parent.  Subsequent replies in the thread
+  // are matched directly by their thread jid.  Each thread gets its own
+  // session-dir, so threads are isolated Pi conversations that share the
+  // parent's persistent workspace files.
+  try {
+    const isAlreadyInThread =
+      typeof message.channel.isThread === 'function' && message.channel.isThread();
+    if (config.autoThread && !isDM && !isAlreadyInThread && 'startThread' in message) {
+      const threadName =
+        (content || senderName || 'conversation')
+          .slice(0, 80)
+          .replace(/\s+/g, ' ')
+          .trim() || 'conversation';
+      const thread = await message.startThread({
+        name: threadName,
+        autoArchiveDuration: config.autoThreadArchiveMinutes as ThreadAutoArchiveDuration,
+      });
+      if (thread?.id) {
+        const threadJid = `dc:${thread.id}`;
+        const threadReg: RegisteredChannel = {
+          jid: threadJid,
+          name: `${channel.name} → ${threadName}`,
+          folder: `ch_${thread.id}`,
+          requiresTrigger: false,
+          isMain: false,
+          modelOverride: channel.modelOverride || '',
+          thinkingOverride: channel.thinkingOverride || '',
+          cwdOverride: channel.cwdOverride || '',
+        };
+        dbRegisterChannel(threadReg);
+        logger.info(
+          { parent: jid, thread: threadJid, name: threadName },
+          'Auto-created Discord thread',
+        );
+        channel = threadReg;
+      }
+    }
+  } catch (err) {
+    logger.warn(
+      { jid, err: (err as Error)?.message },
+      'Auto-thread creation failed; falling back to parent channel',
+    );
+  }
+
   // ── Enqueue ──
   enqueueMessage({
-    channelJid: jid,
+    channelJid: channel.jid,
     sender,
     senderName,
     content,
     timestamp,
     attachments: attachmentsJson,
   });
-  logger.info({ jid, sender: senderName, len: content.length }, 'Message enqueued');
+  logger.info({ jid: channel.jid, sender: senderName, len: content.length }, 'Message enqueued');
 }
 
 // ── Outbound ──

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -239,44 +239,14 @@ async function handleMessage(message: Message): Promise<void> {
   // are matched directly by their thread jid.  Each thread gets its own
   // session-dir, so threads are isolated Pi conversations that share the
   // parent's persistent workspace files.
-  try {
-    const isAlreadyInThread =
-      typeof message.channel.isThread === 'function' && message.channel.isThread();
-    if (config.autoThread && !isDM && !isAlreadyInThread && 'startThread' in message) {
-      const threadName =
-        (content || senderName || 'conversation')
-          .slice(0, 80)
-          .replace(/\s+/g, ' ')
-          .trim() || 'conversation';
-      const thread = await message.startThread({
-        name: threadName,
-        autoArchiveDuration: config.autoThreadArchiveMinutes as ThreadAutoArchiveDuration,
-      });
-      if (thread?.id) {
-        const threadJid = `dc:${thread.id}`;
-        const threadReg: RegisteredChannel = {
-          jid: threadJid,
-          name: `${channel.name} → ${threadName}`,
-          folder: `ch_${thread.id}`,
-          requiresTrigger: false,
-          isMain: false,
-          modelOverride: channel.modelOverride || '',
-          thinkingOverride: channel.thinkingOverride || '',
-          cwdOverride: channel.cwdOverride || '',
-        };
-        dbRegisterChannel(threadReg);
-        logger.info(
-          { parent: jid, thread: threadJid, name: threadName },
-          'Auto-created Discord thread',
-        );
-        channel = threadReg;
-      }
-    }
-  } catch (err) {
-    logger.warn(
-      { jid, err: (err as Error)?.message },
-      'Auto-thread creation failed; falling back to parent channel',
-    );
+  if (config.autoThread && !isDM) {
+    const threadName =
+      (content || senderName || 'conversation')
+        .slice(0, 80)
+        .replace(/\s+/g, ' ')
+        .trim() || 'conversation';
+    const threadReg = await autoThreadOnMessage(message, channel, threadName);
+    if (threadReg) channel = threadReg;
   }
 
   // ── Enqueue ──
@@ -295,8 +265,8 @@ async function handleMessage(message: Message): Promise<void> {
 
 const DISCORD_MAX_LENGTH = 2000;
 
-export async function sendResponse(jid: string, text: string): Promise<boolean> {
-  if (!client) return false;
+export async function sendResponse(jid: string, text: string): Promise<Message | null> {
+  if (!client) return null;
 
   const channelId = jid.replace(/^dc:/, '');
 
@@ -304,26 +274,84 @@ export async function sendResponse(jid: string, text: string): Promise<boolean> 
     const channel = await client.channels.fetch(channelId);
     if (!channel || !('send' in channel)) {
       logger.warn({ jid }, 'Channel not found or not text-based');
-      return false;
+      return null;
     }
 
     const textChannel = channel as TextChannel | DMChannel;
 
+    let firstMessage: Message | null = null;
     if (text.length <= DISCORD_MAX_LENGTH) {
-      await textChannel.send(text);
+      firstMessage = await textChannel.send(text);
     } else {
       // Split at line boundaries when possible
       const chunks = splitMessage(text, DISCORD_MAX_LENGTH);
       for (const chunk of chunks) {
-        await textChannel.send(chunk);
+        const sent = await textChannel.send(chunk);
+        if (!firstMessage) firstMessage = sent;
       }
     }
     logger.info({ jid, length: text.length }, 'Response sent');
-    return true;
+    return firstMessage;
   } catch (err: any) {
     logger.error({ jid, err: err.message }, 'Failed to send message');
-    return false;
+    return null;
   }
+}
+
+/**
+ * Create a Discord thread anchored on the given message and register it
+ * with the same workspace/model/cwd as the parent channel. Used by both
+ * the inbound user-message auto-thread path and the scheduled-task
+ * proactive-checkin path (so cron-fired bot posts don't sit orphaned in
+ * the parent channel).
+ *
+ * Returns the new thread's RegisteredChannel, or undefined if threading
+ * was skipped (already in a thread, no startThread method, error).
+ */
+export async function autoThreadOnMessage(
+  message: { channel?: { isThread?: () => boolean }; startThread?: Function },
+  parentChannel: RegisteredChannel,
+  threadName: string,
+): Promise<RegisteredChannel | undefined> {
+  try {
+    const isAlreadyInThread =
+      typeof message.channel?.isThread === 'function' && message.channel.isThread();
+    if (isAlreadyInThread) return undefined;
+    if (typeof message.startThread !== 'function') return undefined;
+
+    const trimmed = (threadName || 'conversation').slice(0, 80).trim() || 'conversation';
+
+    const thread = await message.startThread({
+      name: trimmed,
+      autoArchiveDuration: config.autoThreadArchiveMinutes as ThreadAutoArchiveDuration,
+    });
+
+    if (thread?.id) {
+      const threadJid = `dc:${thread.id}`;
+      const threadReg: RegisteredChannel = {
+        jid: threadJid,
+        name: `${parentChannel.name} → ${trimmed}`,
+        folder: `ch_${thread.id}`,
+        requiresTrigger: false,
+        isMain: false,
+        modelOverride: parentChannel.modelOverride || '',
+        thinkingOverride: parentChannel.thinkingOverride || '',
+        cwdOverride: parentChannel.cwdOverride || '',
+      };
+      dbRegisterChannel(threadReg);
+      logger.info(
+        { parent: parentChannel.jid, thread: threadJid, name: trimmed },
+        'Auto-created Discord thread',
+      );
+      return threadReg;
+    }
+  } catch (err) {
+    logger.warn(
+      { jid: parentChannel.jid, err: (err as Error)?.message },
+      'Auto-thread creation failed; falling back to parent channel',
+    );
+  }
+  return undefined;
 }
 
 export async function setTyping(jid: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Fix startup peer-dependency check for ESM-only `@earendil-works/pi-ai` by probing with dynamic `import()`.
- Add optional Discord auto-threading via `AUTO_THREAD` / `AUTO_THREAD_ARCHIVE_MIN`; parent channel mentions can spawn per-thread Pi sessions, while thread replies continue without extra mentions.
- Add `prepare` lifecycle script so git+URL installs build `dist/` before the `piscord` bin is used.

## Testing

- `npm run build`
- `npm test` *(initially failed because `better-sqlite3` native bindings were built for a different Node version; after `npm rebuild better-sqlite3`, all 13 test files / 39 tests passed)*

## Notes

This PR contains the fork commits currently ahead of upstream `main`:

- `3e3488a` fix(cli): resolve ESM-only peer dep with dynamic import
- `9820537` feat(discord): optional auto-thread per channel
- `c0ba78b` chore: add prepare script so git+URL installs build dist/