### PR TITLE
Fix pi-ai peer dependency resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- Fix false `Required peer dependency @earendil-works/pi-ai is not installed` startup error when resolving ESM-only pi packages
+
 ## [1.5.2] - 2026-05-16
 
 ### Changed

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { existsSync, realpathSync } from 'node:fs';
-import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { RegisteredChannel } from '../types.js';
@@ -432,26 +431,27 @@ async function reportError(command: string | undefined, err: unknown): Promise<v
 }
 
 function checkPiDependencies(): void {
-  const require = createRequire(import.meta.url);
-
-  try {
-    require.resolve('@earendil-works/pi-ai');
+  if (canResolveImport('@earendil-works/pi-ai')) {
     return;
-  } catch {
-    // not found — check if the legacy package is installed instead
   }
 
   let hint = '';
-  try {
-    require.resolve('@mariozechner/pi-ai');
+  if (canResolveImport('@mariozechner/pi-ai')) {
     hint =
       '\n\nDetected legacy @mariozechner/pi-ai. This package has moved to @earendil-works/pi-ai.' +
       '\nUpgrade pi to v0.74.0+ to get the new packages.';
-  } catch {
-    // neither installed
   }
 
   throw new Error(`Required peer dependency @earendil-works/pi-ai is not installed.${hint}`);
+}
+
+function canResolveImport(specifier: string): boolean {
+  try {
+    import.meta.resolve(specifier);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function maybeRunFirstTimeSetup(): Promise<boolean> {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3,12 +3,17 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { sendFilesToDiscordMock } = vi.hoisted(() => ({
+const { sendFilesToDiscordMock, startGatewayMock } = vi.hoisted(() => ({
   sendFilesToDiscordMock: vi.fn(),
+  startGatewayMock: vi.fn(),
 }));
 
 vi.mock('../src/discord/send.js', () => ({
   sendFilesToDiscord: sendFilesToDiscordMock,
+}));
+
+vi.mock('../src/index.js', () => ({
+  startGateway: startGatewayMock,
 }));
 
 const originalEnv = { ...process.env };
@@ -47,6 +52,19 @@ describe('formatHelpText', () => {
     expect(help).toContain('piscord daemon install');
     expect(help).toContain('piscord send --channel <jid> [--text <message>] [--file <path> ...]');
     expect(help).toContain('--cwd <path>');
+  });
+});
+
+describe('start command', () => {
+  it('does not report ESM-only pi-ai as a missing peer dependency', async () => {
+    process.env.PIDG_CONFIG = resolve('package.json');
+    startGatewayMock.mockResolvedValue(undefined);
+
+    vi.resetModules();
+    const { main } = await import('../src/cli/index.js');
+
+    await expect(main(['start'])).resolves.toBe(0);
+    expect(startGatewayMock).toHaveBeenCalledOnce();
   });
 });
 


### PR DESCRIPTION
## Summary
- Use ESM resolution for pi peer dependency startup checks
- Preserve the legacy `@mariozechner/pi-ai` upgrade hint
- Add regression coverage for the false missing peer dependency error

## Why
`@earendil-works/pi-ai` is ESM/export-map only. `require.resolve('@earendil-works/pi-ai')` can throw `ERR_PACKAGE_PATH_NOT_EXPORTED` even when the package
is installed, causing `piscord start` to incorrectly report:

> Required peer dependency @earendil-works/pi-ai is not installed.

This updates the check to use `import.meta.resolve(...)`, matching the ESM runtime resolution path.

## Validation
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test -- test/cli.test.ts`

Note: full `npm test` currently has unrelated macOS config-path failures in `test/config.test.ts`.