### PR TITLE
feat: respect pi scoped models in Discord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- Discord `/pi model` autocomplete now reads models from the configured pi binary and honors pi's configured `enabledModels` scope.
+
 ## [1.6.1] - 2026-06-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The gateway registers a global `/pi` command on Discord:
 | `/pi new`         | Start a fresh session for this channel                             |
 | `/pi stop`        | Abort the current task and clear queued messages                   |
 
+`/pi model` reads the catalog from the configured `PI_BIN`, so it stays in sync when pi adds or removes models. It also honors pi's `enabledModels` setting (configured through `/scoped-models`), including model order and glob patterns. If no scope is configured, it shows all available models.
+
 ## Tools for Pi
 
 The gateway exposes two capabilities through its CLI that **pi itself can invoke**. You don't type these commands in your terminal — you just tell pi in Discord, and it handles the rest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "croner": "^10.0.1",
         "discord.js": "^14.18.0",
         "dotenv": "^16.5.0",
+        "minimatch": "^10.0.1",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0"
       },
@@ -3801,7 +3802,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3892,7 +3892,6 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5712,7 +5711,6 @@
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "croner": "^10.0.1",
     "discord.js": "^14.18.0",
     "dotenv": "^16.5.0",
+    "minimatch": "^10.0.1",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0"
   },

--- a/src/agent/channel-settings.ts
+++ b/src/agent/channel-settings.ts
@@ -37,7 +37,11 @@ export function computeEffectiveChannelSettings(
   channel: RegisteredChannel,
   options?: { forceRefresh?: boolean },
 ): EffectiveChannelSettings {
-  const models = listAvailableModels({ forceRefresh: options?.forceRefresh ?? false });
+  const effectiveCwd = channel.cwdOverride || config.piCwd;
+  const models = listAvailableModels({
+    forceRefresh: options?.forceRefresh ?? false,
+    cwd: effectiveCwd,
+  });
 
   const rawModelRef = channel.modelOverride || config.piModel || '';
   const modelInfo = rawModelRef ? resolveModelReference(rawModelRef, models) : undefined;
@@ -46,7 +50,6 @@ export function computeEffectiveChannelSettings(
     Boolean(config.piThinking && isThinkingLevel(config.piThinking));
   const desiredThinking = getDesiredThinkingLevel(channel);
   const thinkingResolution = resolveThinkingForModel(modelInfo, desiredThinking);
-  const effectiveCwd = channel.cwdOverride || config.piCwd;
   const cwdSource: EffectiveChannelSettings['cwdSource'] = channel.cwdOverride
     ? 'override'
     : 'default';

--- a/src/agent/invoke.ts
+++ b/src/agent/invoke.ts
@@ -1,6 +1,5 @@
-import { execSync, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
-import { dirname, resolve as pathResolve } from 'node:path';
 import { type AttachmentMeta } from '../discord/attachments.js';
 import { config } from '../config.js';
 import { logger } from '../logger.js';
@@ -11,6 +10,7 @@ import {
   resolveLatestChannelSessionFile,
 } from '../session/path.js';
 import type { AgentResult } from '../types.js';
+import { resolvePiSpawn } from './pi-spawn.js';
 
 export interface SessionTokenUsage {
   input: number;
@@ -484,36 +484,6 @@ function readSessionTokensFromJsonl(sessionFile: string): SessionTokenUsage {
   }
 
   return totals;
-}
-
-function resolvePiSpawn(piBin: string, args: string[]): { bin: string; args: string[] } {
-  if (process.platform !== 'win32') {
-    return { bin: piBin, args };
-  }
-
-  try {
-    const shimPath = execSync(`where ${piBin}`, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-      .split(/\r?\n/)
-      .find((line) => line.trim().endsWith('.cmd'));
-
-    if (shimPath) {
-      const content = readFileSync(shimPath.trim(), 'utf8');
-      const jsMatch = content.match(/"([^"]+\.js)"/);
-      if (jsMatch) {
-        const jsPath = pathResolve(dirname(shimPath.trim()), jsMatch[1]);
-        if (existsSync(jsPath)) {
-          return { bin: process.execPath, args: [jsPath, ...args] };
-        }
-      }
-    }
-  } catch {
-    // Fall through to original.
-  }
-
-  return { bin: piBin, args };
 }
 
 function toNumber(value: number | undefined): number {

--- a/src/agent/model-catalog.ts
+++ b/src/agent/model-catalog.ts
@@ -1,7 +1,11 @@
-import { AuthStorage, ModelRegistry } from '@earendil-works/pi-coding-agent';
+import { spawnSync } from 'node:child_process';
+import { AuthStorage, ModelRegistry, SettingsManager } from '@earendil-works/pi-coding-agent';
 import type { Model } from '@earendil-works/pi-ai';
+import { minimatch } from 'minimatch';
+import { config } from '../config.js';
 import { THINKING_LEVELS, type ThinkingLevel } from '../types.js';
 import { supportsModelXhigh } from './pi-ai-compat.js';
+import { resolvePiSpawn } from './pi-spawn.js';
 
 const CACHE_TTL_MS = 30_000;
 
@@ -16,32 +20,51 @@ export interface AvailableModelInfo {
 
 interface ModelCache {
   loadedAt: number;
+  cwd: string;
   models: AvailableModelInfo[];
 }
 
-let cache: ModelCache | undefined;
+const cacheByCwd = new Map<string, ModelCache>();
 
-export function listAvailableModels(options?: { forceRefresh?: boolean }): AvailableModelInfo[] {
-  const forceRefresh = options?.forceRefresh ?? false;
-  const now = Date.now();
+export interface ModelListOptions {
+  forceRefresh?: boolean;
+  allowStale?: boolean;
+  cwd?: string;
+}
 
-  if (!forceRefresh && cache && now - cache.loadedAt < CACHE_TTL_MS) {
-    return cache.models;
+export function listAvailableModels(options?: ModelListOptions): AvailableModelInfo[] {
+  return loadModelCatalog(
+    options?.forceRefresh ?? false,
+    options?.cwd ?? process.cwd(),
+    options?.allowStale ?? false,
+  ).models;
+}
+
+export function hasCachedModelCatalog(cwd: string): boolean {
+  return cacheByCwd.has(cwd);
+}
+
+/**
+ * Return the models exposed by pi's configured enabledModels scope.
+ * An absent or empty scope preserves the existing all-available-models behavior.
+ */
+export async function listSelectableModels(
+  options?: ModelListOptions,
+): Promise<AvailableModelInfo[]> {
+  const cwd = options?.cwd ?? process.cwd();
+  const catalog = loadModelCatalog(
+    options?.forceRefresh ?? false,
+    cwd,
+    options?.allowStale ?? false,
+  );
+  const settingsManager = SettingsManager.create(cwd);
+  const patterns = settingsManager.getEnabledModels();
+
+  if (!patterns?.length) {
+    return catalog.models;
   }
 
-  const authStorage = AuthStorage.create();
-  authStorage.reload();
-
-  const registry = createModelRegistry(authStorage);
-  registry.refresh();
-
-  const models = registry
-    .getAvailable()
-    .map(toAvailableModelInfo)
-    .sort((a, b) => a.ref.localeCompare(b.ref));
-
-  cache = { loadedAt: now, models };
-  return models;
+  return resolveEnabledModelScope(patterns, catalog.models);
 }
 
 export function resolveModelReference(
@@ -88,8 +111,12 @@ export function resolveModelReference(
   return partialMatches[0];
 }
 
-export function autocompleteModels(query: string, limit = 25): AvailableModelInfo[] {
-  const models = listAvailableModels();
+export async function autocompleteModels(
+  query: string,
+  limit = 25,
+  options?: ModelListOptions,
+): Promise<AvailableModelInfo[]> {
+  const models = await listSelectableModels(options);
   const trimmed = query.trim();
   if (!trimmed) {
     return models.slice(0, limit);
@@ -153,6 +180,192 @@ export function resolveThinkingForModel(
 export function toModelChoiceName(model: AvailableModelInfo): string {
   const label = model.name && model.name !== model.id ? `${model.ref} — ${model.name}` : model.ref;
   return label.length > 100 ? `${label.slice(0, 97)}...` : label;
+}
+
+function resolveEnabledModelScope(
+  patterns: string[],
+  models: AvailableModelInfo[],
+): AvailableModelInfo[] {
+  const scopedModels: AvailableModelInfo[] = [];
+
+  for (const pattern of patterns) {
+    if (hasGlobCharacters(pattern)) {
+      const globPattern = stripThinkingLevel(pattern);
+      const matches = models.filter((model) =>
+        [`${model.provider}/${model.id}`, model.id].some((ref) =>
+          minimatch(ref, globPattern, { nocase: true }),
+        ),
+      );
+
+      for (const model of matches) {
+        addUniqueModel(scopedModels, model);
+      }
+      continue;
+    }
+
+    const model = resolveScopePattern(pattern, models);
+    if (model) {
+      addUniqueModel(scopedModels, model);
+    }
+  }
+
+  return scopedModels;
+}
+
+function resolveScopePattern(
+  pattern: string,
+  models: AvailableModelInfo[],
+): AvailableModelInfo | undefined {
+  const exact = findExactScopeMatch(pattern, models);
+  if (exact) return exact;
+
+  const partialMatches = models.filter(
+    (model) =>
+      model.id.toLowerCase().includes(pattern.toLowerCase()) ||
+      model.name?.toLowerCase().includes(pattern.toLowerCase()),
+  );
+  if (partialMatches.length > 0) {
+    const aliases = partialMatches.filter((model) => !/-\d{8}$/.test(model.id));
+    return (aliases.length > 0 ? aliases : partialMatches).sort((a, b) =>
+      b.id.localeCompare(a.id),
+    )[0];
+  }
+
+  const colonIndex = pattern.lastIndexOf(':');
+  if (colonIndex !== -1) {
+    return resolveScopePattern(pattern.slice(0, colonIndex), models);
+  }
+
+  return undefined;
+}
+
+function findExactScopeMatch(
+  pattern: string,
+  models: AvailableModelInfo[],
+): AvailableModelInfo | undefined {
+  const normalized = pattern.trim().toLowerCase();
+  const canonicalMatches = models.filter(
+    (model) => `${model.provider}/${model.id}`.toLowerCase() === normalized,
+  );
+  if (canonicalMatches.length === 1) return canonicalMatches[0];
+  if (canonicalMatches.length > 1) return undefined;
+
+  const idMatches = models.filter((model) => model.id.toLowerCase() === normalized);
+  return idMatches.length === 1 ? idMatches[0] : undefined;
+}
+
+function stripThinkingLevel(pattern: string): string {
+  const colonIndex = pattern.lastIndexOf(':');
+  if (colonIndex === -1) return pattern;
+
+  const suffix = pattern.slice(colonIndex + 1);
+  return [...THINKING_LEVELS, 'max'].includes(suffix as ThinkingLevel | 'max')
+    ? pattern.slice(0, colonIndex)
+    : pattern;
+}
+
+function hasGlobCharacters(pattern: string): boolean {
+  return pattern.includes('*') || pattern.includes('?') || pattern.includes('[');
+}
+
+function addUniqueModel(models: AvailableModelInfo[], candidate: AvailableModelInfo): void {
+  if (!models.some((model) => model.provider === candidate.provider && model.id === candidate.id)) {
+    models.push(candidate);
+  }
+}
+
+function loadModelCatalog(forceRefresh: boolean, cwd: string, allowStale: boolean): ModelCache {
+  const now = Date.now();
+  const cached = cacheByCwd.get(cwd);
+
+  if (!forceRefresh && cached && (allowStale || now - cached.loadedAt < CACHE_TTL_MS)) {
+    return cached;
+  }
+
+  const authStorage = AuthStorage.create();
+  authStorage.reload();
+
+  const registry = createModelRegistry(authStorage);
+  registry.refresh();
+
+  const sdkModels = registry.getAvailable().map(toAvailableModelInfo);
+  const cliModels = listModelsFromPiCli(config.piBin, cwd);
+  const models = mergeModelMetadata(cliModels ?? sdkModels, sdkModels).sort((a, b) =>
+    a.ref.localeCompare(b.ref),
+  );
+
+  const refreshed = { loadedAt: now, cwd, models };
+  cacheByCwd.set(cwd, refreshed);
+  return refreshed;
+}
+
+function listModelsFromPiCli(piBin: string, cwd: string): AvailableModelInfo[] | undefined {
+  const { bin, args } = resolvePiSpawn(piBin, ['--list-models']);
+  const result = spawnSync(bin, args, {
+    cwd,
+    env: process.env,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    maxBuffer: 10 * 1024 * 1024,
+  });
+
+  if (result.error || result.status !== 0 || !result.stdout) {
+    return undefined;
+  }
+
+  return parsePiModelList(result.stdout);
+}
+
+export function parsePiModelList(output: string): AvailableModelInfo[] {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length < 2) return [];
+
+  const headers = lines[0].split(/\s+/);
+  const providerIndex = headers.indexOf('provider');
+  const modelIndex = headers.indexOf('model');
+  const thinkingIndex = headers.indexOf('thinking');
+  if (providerIndex === -1 || modelIndex === -1 || thinkingIndex === -1) return [];
+
+  return lines.slice(1).flatMap((line) => {
+    const columns = line.split(/\s+/);
+    const provider = columns[providerIndex];
+    const id = columns[modelIndex];
+    if (!provider || !id) return [];
+
+    const reasoning = columns[thinkingIndex]?.toLowerCase() === 'yes';
+    return [
+      {
+        ref: `${provider}/${id}`,
+        provider,
+        id,
+        name: id,
+        reasoning,
+        // The text table exposes only yes/no thinking support. Let pi perform
+        // model-specific clamping for CLI-only models unknown to the bundled SDK.
+        supportsXhigh: reasoning,
+      },
+    ];
+  });
+}
+
+function mergeModelMetadata(
+  sourceModels: AvailableModelInfo[],
+  sdkModels: AvailableModelInfo[],
+): AvailableModelInfo[] {
+  const sdkByRef = new Map(sdkModels.map((model) => [model.ref.toLowerCase(), model]));
+  return sourceModels.map((model) => {
+    const sdkModel = sdkByRef.get(model.ref.toLowerCase());
+    return sdkModel
+      ? {
+          ...model,
+          name: sdkModel.name,
+          supportsXhigh: sdkModel.supportsXhigh,
+        }
+      : model;
+  });
 }
 
 function createModelRegistry(authStorage: AuthStorage): ModelRegistry {

--- a/src/agent/model-catalog.ts
+++ b/src/agent/model-catalog.ts
@@ -8,6 +8,9 @@ import { supportsModelXhigh } from './pi-ai-compat.js';
 import { resolvePiSpawn } from './pi-spawn.js';
 
 const CACHE_TTL_MS = 30_000;
+// A hung `pi --list-models` (broken wrapper, stuck provider lookup) must not
+// block gateway startup or the event loop indefinitely.
+const LIST_MODELS_TIMEOUT_MS = 15_000;
 
 export interface AvailableModelInfo {
   ref: string;
@@ -42,6 +45,11 @@ export function listAvailableModels(options?: ModelListOptions): AvailableModelI
 
 export function hasCachedModelCatalog(cwd: string): boolean {
   return cacheByCwd.has(cwd);
+}
+
+export function isModelCatalogStale(cwd: string): boolean {
+  const cached = cacheByCwd.get(cwd);
+  return !cached || Date.now() - cached.loadedAt >= CACHE_TTL_MS;
 }
 
 /**
@@ -300,13 +308,22 @@ function loadModelCatalog(forceRefresh: boolean, cwd: string, allowStale: boolea
 }
 
 function listModelsFromPiCli(piBin: string, cwd: string): AvailableModelInfo[] | undefined {
-  const { bin, args } = resolvePiSpawn(piBin, ['--list-models']);
+  const cliArgs = ['--list-models'];
+
+  // Match the agent invocation so models registered by PI_EXTRA_FLAGS
+  // extensions are discovered too.
+  if (config.piExtraFlags) {
+    cliArgs.push(...config.piExtraFlags.split(/\s+/).filter(Boolean));
+  }
+
+  const { bin, args } = resolvePiSpawn(piBin, cliArgs);
   const result = spawnSync(bin, args, {
     cwd,
     env: process.env,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
     maxBuffer: 10 * 1024 * 1024,
+    timeout: LIST_MODELS_TIMEOUT_MS,
   });
 
   if (result.error || result.status !== 0 || !result.stdout) {
@@ -316,26 +333,45 @@ function listModelsFromPiCli(piBin: string, cwd: string): AvailableModelInfo[] |
   return parsePiModelList(result.stdout);
 }
 
+interface ModelTableHeader {
+  providerIndex: number;
+  modelIndex: number;
+  thinkingIndex: number;
+  rowsStart: number;
+}
+
+// Extensions or hooks loaded by --list-models can write banners to stdout
+// before the table, so scan for the header row instead of assuming it is the
+// first line.
+function findModelTableHeader(lines: string[]): ModelTableHeader | undefined {
+  for (const [index, line] of lines.entries()) {
+    const headers = line.split(/\s+/);
+    const providerIndex = headers.indexOf('provider');
+    const modelIndex = headers.indexOf('model');
+    const thinkingIndex = headers.indexOf('thinking');
+    if (providerIndex !== -1 && modelIndex !== -1 && thinkingIndex !== -1) {
+      return { providerIndex, modelIndex, thinkingIndex, rowsStart: index + 1 };
+    }
+  }
+  return undefined;
+}
+
 export function parsePiModelList(output: string): AvailableModelInfo[] {
   const lines = output
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
-  if (lines.length < 2) return [];
 
-  const headers = lines[0].split(/\s+/);
-  const providerIndex = headers.indexOf('provider');
-  const modelIndex = headers.indexOf('model');
-  const thinkingIndex = headers.indexOf('thinking');
-  if (providerIndex === -1 || modelIndex === -1 || thinkingIndex === -1) return [];
+  const header = findModelTableHeader(lines);
+  if (!header) return [];
 
-  return lines.slice(1).flatMap((line) => {
+  return lines.slice(header.rowsStart).flatMap((line) => {
     const columns = line.split(/\s+/);
-    const provider = columns[providerIndex];
-    const id = columns[modelIndex];
+    const provider = columns[header.providerIndex];
+    const id = columns[header.modelIndex];
     if (!provider || !id) return [];
 
-    const reasoning = columns[thinkingIndex]?.toLowerCase() === 'yes';
+    const reasoning = columns[header.thinkingIndex]?.toLowerCase() === 'yes';
     return [
       {
         ref: `${provider}/${id}`,

--- a/src/agent/pi-spawn.ts
+++ b/src/agent/pi-spawn.ts
@@ -1,0 +1,34 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve as pathResolve } from 'node:path';
+
+/** Resolve npm .cmd shims on Windows so pi can be spawned without a shell. */
+export function resolvePiSpawn(piBin: string, args: string[]): { bin: string; args: string[] } {
+  if (process.platform !== 'win32') {
+    return { bin: piBin, args };
+  }
+
+  try {
+    const shimPath = execSync(`where ${piBin}`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+      .split(/\r?\n/)
+      .find((line) => line.trim().endsWith('.cmd'));
+
+    if (shimPath) {
+      const content = readFileSync(shimPath.trim(), 'utf8');
+      const jsMatch = content.match(/"([^"]+\.js)"/);
+      if (jsMatch) {
+        const jsPath = pathResolve(dirname(shimPath.trim()), jsMatch[1]);
+        if (existsSync(jsPath)) {
+          return { bin: process.execPath, args: [jsPath, ...args] };
+        }
+      }
+    }
+  } catch {
+    // Fall through to the configured binary.
+  }
+
+  return { bin: piBin, args };
+}

--- a/src/discord/slash-commands.ts
+++ b/src/discord/slash-commands.ts
@@ -25,8 +25,10 @@ import {
 import { logger } from '../logger.js';
 import {
   autocompleteModels,
+  hasCachedModelCatalog,
   isThinkingLevel,
   listAvailableModels,
+  listSelectableModels,
   resolveModelReference,
   resolveThinkingForModel,
   toModelChoiceName,
@@ -102,8 +104,28 @@ export async function handleAutocomplete(interaction: AutocompleteInteraction): 
   if (interaction.options.getSubcommand() !== 'model') return;
   if (interaction.options.getFocused(true).name !== 'model') return;
 
+  const channel = getChannel(`dc:${interaction.channelId}`);
+  if (!channel) {
+    await interaction.respond([]);
+    return;
+  }
+
+  const cwd = channel.cwdOverride || config.piCwd;
+  if (!hasCachedModelCatalog(cwd)) {
+    await interaction.respond([]);
+    setImmediate(() => {
+      try {
+        listAvailableModels({ forceRefresh: true, cwd });
+      } catch (err: any) {
+        logger.warn({ cwd, err: err.message }, 'Failed to warm model catalog');
+      }
+    });
+    return;
+  }
+
   const focused = interaction.options.getFocused();
-  const matches = autocompleteModels(focused, 25).map((model) => ({
+  const models = await autocompleteModels(focused, 25, { allowStale: true, cwd });
+  const matches = models.map((model) => ({
     name: toModelChoiceName(model),
     value: model.ref,
   }));
@@ -238,11 +260,16 @@ async function handleModelSet(interaction: ChatInputCommandInteraction): Promise
     return;
   }
 
+  await interaction.deferReply(
+    interaction.inGuild() ? { flags: MessageFlags.Ephemeral } : undefined,
+  );
+
   const selectedRef = interaction.options.getString('model', true);
-  const models = listAvailableModels({ forceRefresh: true });
+  const cwd = channel.cwdOverride || config.piCwd;
+  const models = await listSelectableModels({ forceRefresh: true, cwd });
   const selectedModel = resolveModelReference(selectedRef, models);
   if (!selectedModel) {
-    await interaction.reply(reply(`Model is no longer available: ${selectedRef}`, interaction));
+    await interaction.editReply({ content: `Model is no longer available: ${selectedRef}` });
     return;
   }
 
@@ -269,7 +296,7 @@ async function handleModelSet(interaction: ChatInputCommandInteraction): Promise
     );
   }
 
-  await interaction.reply(reply(notes.join('\n'), interaction));
+  await interaction.editReply({ content: notes.join('\n') });
 }
 
 async function handleModelReset(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -278,6 +305,10 @@ async function handleModelReset(interaction: ChatInputCommandInteraction): Promi
     await interaction.reply(reply(notRegisteredMessage(), interaction));
     return;
   }
+
+  await interaction.deferReply(
+    interaction.inGuild() ? { flags: MessageFlags.Ephemeral } : undefined,
+  );
 
   clearChannelModelOverride(channel.jid);
 
@@ -298,7 +329,7 @@ async function handleModelReset(interaction: ChatInputCommandInteraction): Promi
     );
   }
 
-  await interaction.reply(reply(notes.join('\n'), interaction));
+  await interaction.editReply({ content: notes.join('\n') });
 }
 
 async function handleThinkingSet(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -313,6 +344,10 @@ async function handleThinkingSet(interaction: ChatInputCommandInteraction): Prom
     await interaction.reply(reply(`Invalid thinking level: ${rawLevel}`, interaction));
     return;
   }
+
+  await interaction.deferReply(
+    interaction.inGuild() ? { flags: MessageFlags.Ephemeral } : undefined,
+  );
 
   const effective = computeEffectiveChannelSettings(channel, { forceRefresh: true });
   const resolution = resolveThinkingForModel(effective.modelInfo, rawLevel);
@@ -330,7 +365,7 @@ async function handleThinkingSet(interaction: ChatInputCommandInteraction): Prom
     );
   }
 
-  await interaction.reply(reply(notes.join('\n'), interaction));
+  await interaction.editReply({ content: notes.join('\n') });
 }
 
 function ensureManagedChannel(

--- a/src/discord/slash-commands.ts
+++ b/src/discord/slash-commands.ts
@@ -26,6 +26,7 @@ import { logger } from '../logger.js';
 import {
   autocompleteModels,
   hasCachedModelCatalog,
+  isModelCatalogStale,
   isThinkingLevel,
   listAvailableModels,
   listSelectableModels,
@@ -99,6 +100,23 @@ export async function registerGlobalCommands(client: Client<true>): Promise<void
   logger.info('Registered global slash commands');
 }
 
+const catalogRefreshesInFlight = new Set<string>();
+
+/** Refresh a cwd's model catalog off the interaction path, at most once at a time. */
+function scheduleCatalogRefresh(cwd: string): void {
+  if (catalogRefreshesInFlight.has(cwd)) return;
+  catalogRefreshesInFlight.add(cwd);
+  setImmediate(() => {
+    try {
+      listAvailableModels({ forceRefresh: true, cwd });
+    } catch (err: any) {
+      logger.warn({ cwd, err: err.message }, 'Failed to warm model catalog');
+    } finally {
+      catalogRefreshesInFlight.delete(cwd);
+    }
+  });
+}
+
 export async function handleAutocomplete(interaction: AutocompleteInteraction): Promise<void> {
   if (interaction.commandName !== 'pi') return;
   if (interaction.options.getSubcommand() !== 'model') return;
@@ -113,13 +131,7 @@ export async function handleAutocomplete(interaction: AutocompleteInteraction): 
   const cwd = channel.cwdOverride || config.piCwd;
   if (!hasCachedModelCatalog(cwd)) {
     await interaction.respond([]);
-    setImmediate(() => {
-      try {
-        listAvailableModels({ forceRefresh: true, cwd });
-      } catch (err: any) {
-        logger.warn({ cwd, err: err.message }, 'Failed to warm model catalog');
-      }
-    });
+    scheduleCatalogRefresh(cwd);
     return;
   }
 
@@ -131,6 +143,13 @@ export async function handleAutocomplete(interaction: AutocompleteInteraction): 
   }));
 
   await interaction.respond(matches);
+
+  // Serve stale results within Discord's deadline, but refresh expired
+  // catalogs in the background so autocomplete-only users still pick up
+  // pi upgrades and provider changes.
+  if (isModelCatalogStale(cwd)) {
+    scheduleCatalogRefresh(cwd);
+  }
 }
 
 export async function handleChatCommand(interaction: ChatInputCommandInteraction): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import { config } from './config.js';
 import { logger } from './logger.js';
-import { initDb, closeDb } from './db.js';
+import { initDb, closeDb, getAllChannels } from './db.js';
 import { startDiscord, stopDiscord, getBotTag } from './discord/client.js';
 import { startArchiveCleanup } from './session/archive-cleanup.js';
 import { startMediaCleanup } from './session/media.js';
+import { listAvailableModels } from './agent/model-catalog.js';
 import { startProcessingLoop, stopProcessingLoop } from './agent/queue.js';
 import { startScheduler } from './agent/scheduler.js';
 
@@ -72,6 +73,7 @@ export async function startGateway(): Promise<void> {
 
   try {
     logger.info('Starting pi-discord-gateway...');
+    warmModelCatalogs();
 
     await startDiscord();
     if (shutdownPromise) {
@@ -100,5 +102,23 @@ export async function startGateway(): Promise<void> {
   } catch (err) {
     await shutdown('startup failure');
     throw err;
+  }
+}
+
+function warmModelCatalogs(): void {
+  const workingDirectories = new Set([
+    config.piCwd,
+    ...getAllChannels()
+      .map((channel) => channel.cwdOverride)
+      .filter(Boolean),
+  ]);
+
+  for (const cwd of workingDirectories) {
+    try {
+      const models = listAvailableModels({ forceRefresh: true, cwd });
+      logger.info({ cwd, models: models.length }, 'Model catalog warmed');
+    } catch (err: any) {
+      logger.warn({ cwd, err: err.message }, 'Failed to warm model catalog');
+    }
   }
 }

--- a/test/model-catalog.test.ts
+++ b/test/model-catalog.test.ts
@@ -1,0 +1,121 @@
+import { AuthStorage, ModelRegistry, SettingsManager } from '@earendil-works/pi-coding-agent';
+import type { Model } from '@earendil-works/pi-ai';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { listSelectableModels, parsePiModelList } from '../src/agent/model-catalog.js';
+
+const { spawnSyncMock } = vi.hoisted(() => ({ spawnSyncMock: vi.fn() }));
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
+  spawnSync: spawnSyncMock,
+}));
+
+const models = [
+  {
+    provider: 'test',
+    id: 'alpha',
+    name: 'Alpha',
+    reasoning: false,
+  },
+  {
+    provider: 'test',
+    id: 'beta',
+    name: 'Beta',
+    reasoning: true,
+  },
+  {
+    provider: 'other',
+    id: 'gamma',
+    name: 'Gamma',
+    reasoning: true,
+  },
+] as Model<any>[];
+
+const defaultCliOutput = `provider  model  context  max-out  thinking  images
+other    gamma  128K     16K      yes       no
+test     alpha  128K     16K      no        no
+test     beta   128K     16K      yes       no
+`;
+
+function mockPiCatalog(enabledModels?: string[], cliOutput = defaultCliOutput): void {
+  const authStorage = { reload: vi.fn() } as unknown as AuthStorage;
+  const registry = {
+    refresh: vi.fn(),
+    getAvailable: vi.fn(() => models),
+  } as unknown as ModelRegistry;
+
+  spawnSyncMock.mockReturnValue({ status: 0, stdout: cliOutput, stderr: '' });
+  vi.spyOn(AuthStorage, 'create').mockReturnValue(authStorage);
+  vi.spyOn(ModelRegistry, 'create').mockReturnValue(registry);
+  vi.spyOn(SettingsManager, 'create').mockReturnValue(SettingsManager.inMemory({ enabledModels }));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  spawnSyncMock.mockReset();
+});
+
+describe('listSelectableModels', () => {
+  it('returns every available model when enabledModels is not configured', async () => {
+    mockPiCatalog();
+
+    const result = await listSelectableModels({ forceRefresh: true, cwd: '/tmp/project' });
+
+    expect(result.map((model) => model.ref)).toEqual(['other/gamma', 'test/alpha', 'test/beta']);
+    expect(SettingsManager.create).toHaveBeenCalledWith('/tmp/project');
+  });
+
+  it('uses pi enabledModels semantics and preserves configured order', async () => {
+    mockPiCatalog(['other/gamma', 'test/alpha']);
+
+    const result = await listSelectableModels({ forceRefresh: true });
+
+    expect(result.map((model) => model.ref)).toEqual(['other/gamma', 'test/alpha']);
+  });
+
+  it('supports the same glob patterns as pi scoped models', async () => {
+    mockPiCatalog(['test/*']);
+
+    const result = await listSelectableModels({ forceRefresh: true });
+
+    expect(result.map((model) => model.ref)).toEqual(['test/alpha', 'test/beta']);
+  });
+
+  it('uses the configured pi binary as the authoritative model source', async () => {
+    mockPiCatalog(
+      ['test/delta'],
+      `${defaultCliOutput}test     delta  256K     32K      yes       yes\n`,
+    );
+
+    const result = await listSelectableModels({ forceRefresh: true });
+
+    expect(result.map((model) => model.ref)).toEqual(['test/delta']);
+  });
+
+  it('falls back to the SDK catalog when pi --list-models fails', async () => {
+    mockPiCatalog(['test/beta']);
+    spawnSyncMock.mockReturnValue({ status: 1, stdout: '', stderr: 'failed' });
+
+    const result = await listSelectableModels({ forceRefresh: true });
+
+    expect(result.map((model) => model.ref)).toEqual(['test/beta']);
+  });
+
+  it('keeps a successful empty pi catalog empty instead of falling back', async () => {
+    mockPiCatalog(undefined, 'provider  model  context  max-out  thinking  images\n');
+
+    const result = await listSelectableModels({ forceRefresh: true });
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('parsePiModelList', () => {
+  it('parses pi --list-models table output', () => {
+    expect(parsePiModelList(defaultCliOutput)).toEqual([
+      expect.objectContaining({ ref: 'other/gamma', reasoning: true }),
+      expect.objectContaining({ ref: 'test/alpha', reasoning: false }),
+      expect.objectContaining({ ref: 'test/beta', reasoning: true }),
+    ]);
+  });
+});

--- a/test/model-catalog.test.ts
+++ b/test/model-catalog.test.ts
@@ -1,7 +1,12 @@
 import { AuthStorage, ModelRegistry, SettingsManager } from '@earendil-works/pi-coding-agent';
 import type { Model } from '@earendil-works/pi-ai';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { listSelectableModels, parsePiModelList } from '../src/agent/model-catalog.js';
+import {
+  isModelCatalogStale,
+  listSelectableModels,
+  parsePiModelList,
+} from '../src/agent/model-catalog.js';
+import { config } from '../src/config.js';
 
 const { spawnSyncMock } = vi.hoisted(() => ({ spawnSyncMock: vi.fn() }));
 
@@ -108,6 +113,72 @@ describe('listSelectableModels', () => {
 
     expect(result).toEqual([]);
   });
+
+  it('falls back to the SDK catalog when pi --list-models errors out', async () => {
+    mockPiCatalog(['test/beta']);
+    spawnSyncMock.mockReturnValue({
+      error: new Error('spawnSync pi ETIMEDOUT'),
+      status: null,
+      stdout: '',
+      stderr: '',
+    });
+
+    const result = await listSelectableModels({ forceRefresh: true });
+
+    expect(result.map((model) => model.ref)).toEqual(['test/beta']);
+  });
+
+  it('bounds the pi --list-models subprocess with a timeout', async () => {
+    mockPiCatalog();
+
+    await listSelectableModels({ forceRefresh: true });
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  it('passes PI_EXTRA_FLAGS to model discovery like the agent invocation', async () => {
+    mockPiCatalog();
+    const mutableConfig = config as { piExtraFlags: string };
+    const previousFlags = mutableConfig.piExtraFlags;
+    mutableConfig.piExtraFlags = '-e ./provider.ts --approve';
+
+    try {
+      await listSelectableModels({ forceRefresh: true });
+    } finally {
+      mutableConfig.piExtraFlags = previousFlags;
+    }
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      expect.anything(),
+      ['--list-models', '-e', './provider.ts', '--approve'],
+      expect.anything(),
+    );
+  });
+});
+
+describe('isModelCatalogStale', () => {
+  it('treats never-loaded catalogs as stale', () => {
+    expect(isModelCatalogStale('/tmp/never-loaded')).toBe(true);
+  });
+
+  it('reports stale once the cache TTL elapses', async () => {
+    vi.useFakeTimers();
+    try {
+      mockPiCatalog();
+      await listSelectableModels({ forceRefresh: true, cwd: '/tmp/stale-check' });
+
+      expect(isModelCatalogStale('/tmp/stale-check')).toBe(false);
+
+      vi.advanceTimersByTime(31_000);
+      expect(isModelCatalogStale('/tmp/stale-check')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('parsePiModelList', () => {
@@ -117,5 +188,19 @@ describe('parsePiModelList', () => {
       expect.objectContaining({ ref: 'test/alpha', reasoning: false }),
       expect.objectContaining({ ref: 'test/beta', reasoning: true }),
     ]);
+  });
+
+  it('skips banner output written before the table header', () => {
+    const output = `Loaded extension ./provider.ts\nwarning: model cache rebuilt\n${defaultCliOutput}`;
+
+    expect(parsePiModelList(output)).toEqual([
+      expect.objectContaining({ ref: 'other/gamma', reasoning: true }),
+      expect.objectContaining({ ref: 'test/alpha', reasoning: false }),
+      expect.objectContaining({ ref: 'test/beta', reasoning: true }),
+    ]);
+  });
+
+  it('returns an empty catalog when no table header is present', () => {
+    expect(parsePiModelList('no models available\n')).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Keep Discord's `/pi model` catalog in sync with the configured pi binary and honor pi's `enabledModels` scope instead of always exposing Piscord's bundled SDK catalog.

## Changes

- Read the authoritative available-model catalog from `PI_BIN --list-models`, with the SDK catalog as a compatibility fallback only when the command fails.
- Load merged pi settings for the channel's effective working directory.
- Resolve `enabledModels` with pi-compatible exact, partial, thinking-suffix, and glob matching while preserving configured order.
- Keep the existing full-list behavior when `enabledModels` is absent or empty.
- Validate submitted model choices against the same scoped list.
- Prewarm per-cwd catalogs at startup and serve autocomplete exclusively from cache to stay inside Discord's response deadline.
- Reject autocomplete in unmanaged channels without launching pi.
- Defer slash-command replies before forced catalog refreshes.
- Reuse Piscord's cross-platform pi spawn resolution for model discovery and agent invocation.
- Add model-source, scope, glob, parser, empty-result, and fallback tests plus user-facing documentation.

## Test Plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test`
- [x] `npm run build`
- [x] Node 20 and Node 22 CI pass.
- [x] Manually verified both local registered working directories resolve to exactly the four configured OpenAI Codex scoped models, including the newer 5.6 models absent from Piscord's bundled SDK catalog.
- [x] Restarted the local systemd service on this PR build and verified catalog warmup, Discord connection, slash-command registration, scheduler startup, and gateway health.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] This PR does not include unrelated changes.